### PR TITLE
Revert "updating redhat.yml with new dir path for LocalSocket"

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -20,6 +20,6 @@ clamav_packages:
 # Update virus signatures database each time role runs
 clamav_fresh: true
 ClamAVLogFile: /var/log/clamav/clamav.log
-LocalSocket: /var/run/clamav/clamd.ctl
+LocalSocket: /var/run/clamd.scan/clamd.ctl
 LocalSocketGroup: clamscan
 DatabaseOwner: clamscan


### PR DESCRIPTION
Reverts UKHomeOffice/ansible-role-clamav#3

redhat.yml does not seem to be called by the CentOS 7 box