### PR TITLE
fix: disable bytecode JIT on CentOS6 as it is not supported

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,6 @@ StreamMaxLength: 256M
 LogTime: "true"
 LogFileUnlock: "false"
 LogFileMaxSize: 100M
-Bytecode: "true"
 BytecodeSecurity: Paranoid
 BytecodeTimeout: 60000
 OnAccessMaxFileSize: 256M

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -46,10 +46,6 @@
     state: directory
     mode: 0775
 
-- name: Adjust SELinux Bytecode
-  command: setsebool -P clamd_use_jit on
-  when: ansible_distribution_version < '7'
-
 - name: Adjust SELinux RWX mapping
   command: setsebool -P antivirus_can_scan_system 1
   when: ansible_distribution_version < '7'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,6 +6,7 @@ update_user: clamav
 clamav_daemon: clamav-daemon
 clamav_update: clamav-freshclam
 Foreground: "true"
+Bytecode: "true"
 
 clamav_packages:
   - clamav # for manual usage

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -6,6 +6,7 @@ update_user: clam
 clamav_daemon: clamd
 clamav_update: freshclam
 Foreground: "false"
+Bytecode: "false"
 
 clamav_packages:
 - clamav-db

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,6 +6,7 @@ update_user: clamupdate
 clamav_daemon: clamd
 clamav_update: freshclam
 Foreground: "true"
+Bytecode: "true"
 
 clamav_packages:
 - clamav-server


### PR DESCRIPTION
Remove JIT from CentOS6 code as it is not currently supported