### PR TITLE
Crossing 7071/clam av config update for periodic scans

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,4 +83,4 @@ OnAccessExtraScanning: "true"
 OnAccessMountPath:
  - name: /home
 SafeBrowsing: "true"
-VirusEvent: "for i in $(who | awk '{print$1}' ) ; do su -s /bin/bash -c \"DISPLAY=:0 notify-send -u critical -t 1000 'Possible Virus: $CLAM_VIRUSEVENT_FILENAME > $CLAM_VIRUSEVENT_VIRUSNAME'\" - \"$i\" ; done"
+VirusEvent: "/opt/clamav-utils/clamd-response"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,7 +82,4 @@ OnAccessDisableDDD: "true"
 OnAccessExtraScanning: "true"
 OnAccessMountPath:
  - name: /home
- - name: /var
- - name: /var/lib/docker
- - name: /var/tmp
 SafeBrowsing: "true"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,7 @@ PartitionIntersection: "true"
 DetectPUA: "true"
 ScanPartialMessages: "true"
 HeuristicScanPrecedence: "true"
-StructuredDataDetection: "true"
+StructuredDataDetection: "false"
 CommandReadTimeout: 5
 SendBufTimeout: 500
 MaxQueue: 240
@@ -83,3 +83,4 @@ OnAccessExtraScanning: "true"
 OnAccessMountPath:
  - name: /home
 SafeBrowsing: "true"
+VirusEvent: "for i in $(who | awk '{print$1}' ) ; do su -s /bin/bash -c \"DISPLAY=:0 notify-send -u critical -t 1000 'Possible Virus: $CLAM_VIRUSEVENT_FILENAME > $CLAM_VIRUSEVENT_VIRUSNAME'\" - \"$i\" ; done"

--- a/files/clamav-daemon.service
+++ b/files/clamav-daemon.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Clam AntiVirus userspace daemon
+Documentation=man:clamd(8) man:clamd.conf(5) http://www.clamav.net/lang/en/doc/
+Requires=clamav-daemon.socket
+# Check for database existence
+ConditionPathExistsGlob=/var/lib/clamav/main.{c[vl]d,inc}
+ConditionPathExistsGlob=/var/lib/clamav/daily.{c[vl]d,inc}
+
+[Service]
+ExecStart=/usr/sbin/clamd --foreground=true
+# Reload the database
+ExecReload=/bin/kill -USR2 $MAINPID
+StandardOutput=syslog
+Nice=18
+
+[Install]
+WantedBy=multi-user.target
+Also=clamav-daemon.socket

--- a/files/clamd-response
+++ b/files/clamd-response
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+FILENAME=$( basename $CLAM_VIRUSEVENT_FILENAME )
+QUARANTINE_DIR="/opt/clamav-utils/QUARANTINE/"
+POP_UP_MESSAGE="Quarantined: '${CLAM_VIRUSEVENT_FILENAME} => ${CLAM_VIRUSEVENT_VIRUSNAME}'"
+
+quarantine() {
+  chmod 0400 ${CLAM_VIRUSEVENT_FILENAME}
+  
+  mv ${CLAM_VIRUSEVENT_FILENAME} ${QUARANTINE_DIR}${FILENAME}
+  
+  cd ${QUARANTINE_DIR}
+
+  tar -cvzf ${FILENAME}.gzip ${FILENAME} && \
+  	rm ${QUARANTINE_DIR}${FILENAME}
+
+  chmod 0400 ${QUARANTINE_DIR}${FILENAME}.gzip
+  
+  for i in $(who | awk '{print$1}' ) ; do
+    su -s /bin/bash -c \
+      "DISPLAY=:0 notify-send -u critical -t 1000 ${POP_UP_MESSAGE}" - "$i"
+  done
+}
+
+
+if [ -f ${CLAM_VIRUSEVENT_FILENAME} ]; then
+  quarantine
+fi
+
+exit 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,15 @@
 - name: Include tasks suitable to our OS Family
   include: "{{ ansible_os_family }}.yml"
 
+- name: Set niceness of clamav-daemon within systemd to a lower priority
+  copy:
+    src: clamav-daemon.service
+    dest: /lib/systemd/system/clamav-daemon.service
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart ClamAV
+
 - name: Replace custom clamd.conf
   template:
     dest: "{{ clamd_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,14 @@
   when: "{{ freshclam_enabled }}"
   tags: usb
 
+- name: Set cron job for scanning / at 12:00 on a Wednesday
+  cron:
+    name: clamdscan
+    minute: "0"
+    hour: "12"
+    dow: "4"
+    job: "systemd-cat --identifier='clamav-scan' clamdscan --multiscan --fdpass /"
+
 #- shell: "/usr/local/bin/freshclam_status"
 #  register: result
 #  until: result.stdout.find("OK") != -1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,7 +65,7 @@
     minute: "0"
     hour: "12"
     dow: "4"
-    job: "systemd-cat --identifier='clamav-scan' clamdscan --multiscan --fdpass /"
+    job: "/usr/bin/clamdscan --multiscan --fdpass /"
 
 #- shell: "/usr/local/bin/freshclam_status"
 #  register: result

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,24 @@
 - name: Include tasks suitable to our OS Family
   include: "{{ ansible_os_family }}.yml"
 
+- name: Create QUARANTINE directory for ClamAV
+  file:
+    path: /opt/clamav-utils/QUARANTINE/
+    state: directory
+    owner: root
+    group: root
+    state: 0700
+    recurse: yes
+
+- name: Add clamd VirusEvent script
+  copy:
+    src: clamd-response
+    dest: /opt/clamav-utils/clamd-response
+    owner: root
+    group: root
+    mode: 0700
+  notify: Restart ClamAV
+
 - name: Set niceness of clamav-daemon within systemd to a lower priority
   copy:
     src: clamav-daemon.service
@@ -58,6 +76,13 @@
     enabled: yes
   when: "{{ freshclam_enabled }}"
   tags: usb
+
+- name: Set cron job for emptying QUARANTINE directory of files not used within 3 days
+  cron:
+    name: clamdscan
+    minute: "0"
+    hour: "16"
+    job: "find /opt/clamav-utils/QUARANTINE/ -mindepth 1 -mtime +2 -delete"
 
 - name: Set cron job for scanning / at 12:00 on a Wednesday
   cron:

--- a/templates/clamd.conf.j2
+++ b/templates/clamd.conf.j2
@@ -93,3 +93,4 @@ OnAccessExcludeUID 0
 {% for dir in OnAccessMountPath %}
 OnAccessMountPath {{ dir.name }}
 {% endfor %}
+VirusEvent {{ VirusEvent }}

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -4,6 +4,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = 'hashicorp/precise32'
 
     config.vm.provision :ansible do |ansible|
+        ansible.groups = {
+            "webservers" => ["default"],
+            "dev_environment" => ["default"]
+        }
         ansible.playbook = 'playbook.yml'
         ansible.extra_vars = { ansible_ssh_user: 'vagrant', vagrant: true }
         ansible.verbose = 'vv'


### PR DESCRIPTION
Updates:

tests/Vagrantfile: Added host groups within vagrantfile so tests work

files/clamav-daemon.service: Added so that niceness can be defined

templates/clamd.conf: removed /var/ directories from OnAccessScan.

tasks/main.yml: Added cron job for weekly scanning at 12pm on a Wednesday (when they are most likely to be run?)

files/clamd-response: Quarantine script to be used by default when virus is discovered