### PR TITLE
tasks/main.yml: Fixed typo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
     state: directory
     owner: root
     group: root
-    state: 0700
+    mode: 0700
     recurse: yes
 
 - name: Add clamd VirusEvent script


### PR DESCRIPTION
There was a typo here which caused an error.

The tests within the repo didn't catch it...